### PR TITLE
Better DropChance and SilkTouch Checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,17 @@ This object is the main object returned from the `getPotentialDrops` function. I
 * `lootItemDrop.poolIndex: number`
 <br/> The index of the loot table pool this item drop is located in.
 
-* `lootItemDrop.siblingWeights: [number, number][]`
-<br/> A list of tuples containing the weight and quality of all other drops located in the same pool as this item drop. The first value of the tuple is the item drop weight, and the second value is the item drop quality. The list does not contain this item.
+* `lootItemDrop.entryType: string`
+<br/> This value contains the entry type of the parent entry this item drop occurs from. For item drops not being nested, this is equal to `minecraft:item`. For item drops which are nested inside another entry, this value contains the parent entry's group type. `group`, `alternatives`, or `sequence`. This can be used to calculate more information about how item drops are calculated compared to the siblings
+
+* `lootItemDrop.sibling: LootItemDrop[]`
+<br/> A list of all other item drops that come from the same pool as this item drop. The list also contains this item.
 
 * `lootItemDrop.requiresSilkTouch(): boolean`
 <br/> Checks if any of the drop conditions is a silk touch requirement.
+
+* `lootItemDrop.requiresNoSilkTouch(): boolean`
+<br/> Checks if the item drop requires the tool to not have silk touch.
 
 * `lootItemDrop.estimateDropChance(looting?: number, luck?: number): number`
 <br/> Estimates the drop chance of the item with the given luck potion effect, looting enchantment level and all relevant functions and conditions applied to the item drop. If the looting parameter is not defined, it is defaulted to 0. If the luck parameter is not defined, it is defaulted to 0.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ This object is the main object returned from the `getPotentialDrops` function. I
 * `lootItemDrop.requiresNoSilkTouch(): boolean`
 <br/> Checks if the item drop requires the tool to not have silk touch.
 
+* `lootItemDrop.requiresPlayerKill(): boolean`
+<br/> Checks if the item drop requires the entity to be killed by a player directly.
+
 * `lootItemDrop.estimateDropChance(looting?: number, luck?: number): number`
 <br/> Estimates the drop chance of the item with the given luck potion effect, looting enchantment level and all relevant functions and conditions applied to the item drop. If the looting parameter is not defined, it is defaulted to 0. If the luck parameter is not defined, it is defaulted to 0.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const lootTable = require('./path/to/table.json')
 const drops = getPotentialDrops(lootTable)
 
 const itemType = drops[0].itemType
-const silkTouch = drops[0].conditions[0].isSilkTouch()
+const silkTouch = drops[0].requiresSilkTouch()
 ```
 
 ## API
@@ -60,6 +60,9 @@ This object is the main object returned from the `getPotentialDrops` function. I
 
 * `lootItemDrop.dropChance: number`
 <br/> The estimated chance of this item being dropped, assuming all conditions for all entries are met and the luck enchantment is not being used.
+
+* `lootItemDrop.requiresSilkTouch(): boolean`
+<br/> Checks if any of the drop conditions is a silk touch requirement.
 
 _**LootFunction**_
 

--- a/README.md
+++ b/README.md
@@ -58,11 +58,17 @@ This object is the main object returned from the `getPotentialDrops` function. I
 * `lootItemDrop.quality: number`
 <br/> The bonus weight to add for each point of luck being used. The new weight value is calculated via the formula: `floor(weight + (quality * generic.luck))` More information can be found on the Minecraft wiki page.
 
-* `lootItemDrop.dropChance: number`
-<br/> The estimated chance of this item being dropped, assuming all conditions for all entries are met and the luck enchantment is not being used.
+* `lootItemDrop.poolIndex: number`
+<br/> The index of the loot table pool this item drop is located in.
+
+* `lootItemDrop.siblingWeights: [number, number][]`
+<br/> A list of tuples containing the weight and quality of all other drops located in the same pool as this item drop. The first value of the tuple is the item drop weight, and the second value is the item drop quality. The list does not contain this item.
 
 * `lootItemDrop.requiresSilkTouch(): boolean`
 <br/> Checks if any of the drop conditions is a silk touch requirement.
+
+* `lootItemDrop.estimateDropChance(looting?: number, luck?: number): number`
+<br/> Estimates the drop chance of the item with the given luck potion effect, looting enchantment level and all relevant functions and conditions applied to the item drop. If the looting parameter is not defined, it is defaulted to 0. If the luck parameter is not defined, it is defaulted to 0.
 
 _**LootFunction**_
 
@@ -71,12 +77,18 @@ Contains information about a function to be applied to an item drop. The propert
 * `lootFunction.type: string`
 <br/> The namespaced type of function that is being applied.
 
+* `lootFunction.onPool: boolean`
+<br/> True if this function is applied to the entire pool. False if this function is only applied to the item.
+
 _**LootCondition**_
 
 Contains information about a condition required for an item drop to occur. The properties within this class match the properties of the given type as defined within the Minecraft Loot Table format.
 
 * `lootCondition.type: string`
 <br/> The namespaced type of condition that is being applied.
+
+* `lootCondition.onPool: boolean`
+<br/> True if this condition is applied to the entire pool. False if this condition is only applied to the item.
 
 * `lootCondition.isSilkTouch(): boolean`
 <br/> Checks if the condition is a silk touch check.

--- a/index.js
+++ b/index.js
@@ -207,6 +207,14 @@ class LootItemDrop {
     this.quality = 1.0
     this.dropChance = 1.0
   }
+
+  requiresSilkTouch() {
+    for (const condition of this.conditions) {
+      if (condition.isSilkTouch()) return true
+    }
+
+    return false
+  }
 }
 
 class LootCondition {

--- a/index.js
+++ b/index.js
@@ -232,6 +232,16 @@ class LootItemDrop {
     return false
   }
 
+  requiresPlayerKill () {
+    for (const condition of this.conditions) {
+      if (condition.type === 'minecraft:killed_by_player') {
+        return !condition.inverse
+      }
+    }
+
+    return false
+  }
+
   estimateDropChance (looting = 0, luck = 0) {
     const myWeight = Math.floor(this.weight + (this.quality * luck))
 

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ class LootItemDrop {
     this.dropChance = 1.0
   }
 
-  requiresSilkTouch() {
+  requiresSilkTouch () {
     for (const condition of this.conditions) {
       if (condition.isSilkTouch()) return true
     }
@@ -227,7 +227,7 @@ class LootCondition {
     if (!this.predicate || !this.predicate.enchantments) return false
 
     for (const enchantment of this.predicate.enchantments) {
-      if (enchantment === 'minecraft:silk_touch') return true
+      if (enchantment.enchantment === 'minecraft:silk_touch') return true
     }
 
     return false


### PR DESCRIPTION
This PR fixes a small bug with the silk touch check, as well as adding the silk touch condition to the main item drop so digging through the condition list is no longer required. Also added a quick utility function for `requiresNoSilkTouch()` which should help with conditions were certain drops only occur when not using a silk touch enchantment. (I.e. stone only drops cobble when not using silk touch)

In addition, this PR reworks the drop chance calculation to be much more accurate, taking in randomness conditions, looting enchantments, and luck status effects.